### PR TITLE
Fix import paths after fork, ensure errors on checking existence in Redis are not smothered

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	// "github.com/gin-contrib/cache/persistence"
-	"github.com/Jim-Lambert-Bose/cache/persistence"
+	"github.com/BoseCorp/cache/persistence"
 
 	"github.com/gin-gonic/gin"
 )

--- a/cache_test.go
+++ b/cache_test.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 
 	// "github.com/gin-contrib/cache/persistence"
-	"github.com/Jim-Lambert-Bose/cache/persistence"
+	"github.com/BoseCorp/cache/persistence"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )

--- a/example/example.go
+++ b/example/example.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Jim-Lambert-Bose/cache/persistence"
-	"github.com/Jim-Lambert-Bose/cache"
+	"github.com/BoseCorp/cache/persistence"
+	"github.com/BoseCorp/cache"
 	// "github.com/gin-contrib/cache"
 	// "github.com/gin-contrib/cache/persistence"
 	"github.com/gin-gonic/gin"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Jim-Lambert-Bose/cache
+module github.com/BoseCorp/cache
 
 require (
 	github.com/bradfitz/gomemcache v0.0.0-20190329173943-551aad21a668

--- a/persistence/memcached.go
+++ b/persistence/memcached.go
@@ -3,7 +3,7 @@ package persistence
 import (
 	"time"
 
-	"github.com/Jim-Lambert-Bose/cache/utils"
+	"github.com/BoseCorp/cache/utils"
 	"github.com/bradfitz/gomemcache/memcache"
 	//	"github.com/gin-contrib/cache/utils"
 )

--- a/persistence/memcached_binary.go
+++ b/persistence/memcached_binary.go
@@ -3,7 +3,7 @@ package persistence
 import (
 	"time"
 
-	"github.com/Jim-Lambert-Bose/cache/utils"
+	"github.com/BoseCorp/cache/utils"
 	// "github.com/gin-contrib/cache/utils"
 	"github.com/memcachier/mc"
 )

--- a/persistence/redis.go
+++ b/persistence/redis.go
@@ -7,7 +7,7 @@ import (
 	//"github.com/gin-contrib/cache/utils"
 	"time"
 
-	"github.com/Jim-Lambert-Bose/cache/utils"
+	"github.com/BoseCorp/cache/utils"
 	"github.com/gomodule/redigo/redis"
 )
 
@@ -134,7 +134,11 @@ func (c *RedisStore) MSetNX(expires time.Duration, kv ...interface{}) error {
 func (c *RedisStore) Add(key string, value interface{}, expires time.Duration) error {
 	conn := c.pool.Get()
 	defer conn.Close()
-	if exists(conn, key) {
+	exists, err := exists(conn, key)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return ErrNotStored
 	}
 	return c.invoke(conn.Do, key, value, expires)
@@ -144,7 +148,10 @@ func (c *RedisStore) Add(key string, value interface{}, expires time.Duration) e
 func (c *RedisStore) Replace(key string, value interface{}, expires time.Duration) error {
 	conn := c.pool.Get()
 	defer conn.Close()
-	if !exists(conn, key) {
+	if exists, err := exists(conn, key); !exists {
+		if err != nil {
+			return err
+		}
 		return ErrNotStored
 	}
 	err := c.invoke(conn.Do, key, value, expires)
@@ -203,16 +210,19 @@ func (c *RedisStore) Mget(ptrValue []interface{}, keys ...string) error {
 	return nil
 }
 
-func exists(conn redis.Conn, key string) bool {
-	retval, _ := redis.Bool(conn.Do("EXISTS", key))
-	return retval
+func exists(conn redis.Conn, key string) (bool, error) {
+	retval, err := redis.Bool(conn.Do("EXISTS", key))
+	return retval, err
 }
 
 // Delete (see CacheStore interface)
 func (c *RedisStore) Delete(key string) error {
 	conn := c.pool.Get()
 	defer conn.Close()
-	if !exists(conn, key) {
+	if exists, err := exists(conn, key); !exists {
+		if err != nil {
+			return err
+		}
 		return ErrCacheMiss
 	}
 	_, err := conn.Do("DEL", key)
@@ -329,7 +339,10 @@ func (c *RedisStore) Decrement(key string, delta uint64) (newValue uint64, err e
 	defer conn.Close()
 	// Check for existance *before* increment as per the cache contract.
 	// redis will auto create the key, and we don't want that, hence the exists call
-	if !exists(conn, key) {
+	if exists, err := exists(conn, key); !exists {
+		if err != nil {
+			return 0, err
+		}
 		return 0, ErrCacheMiss
 	}
 	// Decrement contract says you can only go to 0

--- a/persistence/redis_get_expires_in_test.go
+++ b/persistence/redis_get_expires_in_test.go
@@ -4,7 +4,7 @@ package persistence
 import (
 	"testing"
 	"time"
-	// "github.com/Jim-Lambert-Bose/cache/persistence"
+	// "github.com/BoseCorp/cache/persistence"
 
 )
 


### PR DESCRIPTION
This PR accomplishes two things:

1. Fixes import paths due to the new repo.
2. Applies the [fix recommendation from the old repo](https://github.com/Jim-Lambert-Bose/cache/pull/12).
  a. Ensures that Redis operations when checking key existence don't smother errors.